### PR TITLE
Setting -DUSE_GPU_BRIDGE=0 for opm-simulators

### DIFF
--- a/.github/workflows/ci_brew_opm-flow_resinsight_macos.yml
+++ b/.github/workflows/ci_brew_opm-flow_resinsight_macos.yml
@@ -17,15 +17,15 @@ jobs:
       with:
         python-version: 3.14
 
-    - name: Install ResInsight
-      run: |
-        brew install cssr-tools/opm/resinsight
-        which resinsight
-
     - name: Install OPM Flow
       run: |
         brew install cssr-tools/opm/opm-simulators
         which flow
+
+    - name: Install ResInsight
+      run: |
+        brew install cssr-tools/opm/resinsight
+        which resinsight
 
     - name: Run OPM Flow (in parallel)
       run: |

--- a/opm-simulators.rb
+++ b/opm-simulators.rb
@@ -32,7 +32,8 @@ class OpmSimulators < Formula
              "-DCMAKE_BUILD_TYPE=Release",
              "-DPYTHON_EXECUTABLE=#{HOMEBREW_PREFIX}/bin/python3",
              "-DOPM_ENABLE_PYTHON=ON",
-             "-DOPM_ENABLE_EMBEDDED_PYTHON=ON"
+             "-DOPM_ENABLE_EMBEDDED_PYTHON=ON",
+             "-DUSE_GPU_BRIDGE=0"
       system "make", "flow"
       system "make", "install"
     end


### PR DESCRIPTION
Setting `-DUSE_GPU_BRIDGE=0` for opm-simulators to solve `fatal error: 'CL/cl2.hpp' file not found`